### PR TITLE
chore: allow using a configmap

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingConfigMap }}
 {{- $config := omit .Values.sentry "dsn" -}}
 apiVersion: v1
 kind: ConfigMap
@@ -7,3 +8,4 @@ metadata:
 data:
   config.yaml: |-
     {{- $config | toYaml | nindent 4 }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -57,4 +57,4 @@ spec:
       volumes:
         - name: app-config
           configMap:
-            name: {{ template "sentry-kubernetes.fullname" . }}
+            name: {{ .Values.existingConfigMap | default (template "sentry-kubernetes.fullname" .) }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,7 @@
 # Default values for sentry-kubernetes.
 
+# Useful when deploying as a subchart
+existingConfigMap: ""
 sentry:
   dsn: ~
   existingSecret: ~


### PR DESCRIPTION
We are attempting to use this as a subchart.

We have a top level key already defined that we would like to use as a value for `sentry.environment` 

Eg we do the same with this helm chart.
https://github.com/vectordotdev/helm-charts/tree/develop/charts/vector