### PR TITLE
Add guidelines on branch naming and commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Contribution Instructions
+
+## Code formatting
+- Format Rust code using `cargo fmt --all` before committing.
+- Failing to format will cause CI failures.
+
+## Testing
+- Run `cargo test --all-features` to execute the test suite.
+- Ensure tests pass before opening a PR.
+
+## PR Guidance
+- Provide a short summary of changes in the pull request description.
+- Mention any modifications to the Helm chart or Dockerfile explicitly.
+- Use descriptive English branch names.
+- Follow the Conventional Commits specification for commit messages.
+


### PR DESCRIPTION
## Summary
- clarify contribution rules to use English branch names
- require commit messages to follow Conventional Commits

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo test --all-features` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f1200ffac833392dbc703da822613