### PR TITLE
Increase test coverage for ConfigResource

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -172,3 +172,73 @@ pub fn parse_config() -> anyhow::Result<(GlobalConfiguration, Vec<ConfigMonitor>
 
     Ok((global_config, monitors_config))
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{Event, ObjectReference};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use kube::{Client, Config};
+
+    fn build_client() -> CachingClient {
+        let client =
+            Client::try_from(Config::new("https://localhost:6443/".try_into().unwrap())).unwrap();
+        CachingClient::new(client)
+    }
+
+    fn base_event() -> Event {
+        Event {
+            involved_object: ObjectReference {
+                api_version: Some("v1".to_string()),
+                kind: Some("Pod".to_string()),
+                name: Some("pod-1".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            metadata: ObjectMeta::default(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn event_matches_success() {
+        let client = build_client();
+        let event = base_event();
+        let resource = ConfigResource {
+            api_version: Some("v1".to_string()),
+            kind: Some("Pod".to_string()),
+            namespace: Some("default".to_string()),
+            ..Default::default()
+        };
+
+        assert!(resource.event_matches(&event, &client).await);
+    }
+
+    #[tokio::test]
+    async fn event_matches_wrong_namespace() {
+        let client = build_client();
+        let mut event = base_event();
+        event.involved_object.namespace = Some("other".to_string());
+        let resource = ConfigResource {
+            namespace: Some("default".to_string()),
+            kind: Some("Pod".to_string()),
+            api_version: None,
+            label_selector: None,
+        };
+
+        assert!(!resource.event_matches(&event, &client).await);
+    }
+
+    #[tokio::test]
+    async fn event_matches_wrong_kind() {
+        let client = build_client();
+        let event = base_event();
+        let resource = ConfigResource {
+            kind: Some("Node".to_string()),
+            namespace: Some("default".to_string()),
+            api_version: None,
+            label_selector: None,
+        };
+
+        assert!(!resource.event_matches(&event, &client).await);
+    }
+}

--- a/src/selector/mod.rs
+++ b/src/selector/mod.rs
@@ -272,4 +272,39 @@ mod tests {
     fn from_str_invalid() {
         assert!(Selectors::try_from("invalid@@").is_err());
     }
+
+    #[test]
+    fn from_str_negation_and_set_based() {
+        let selector =
+            Selectors::try_from("!env in (prod, test), app notin (sentry)").expect("parse failed");
+
+        assert_eq!(selector.len(), 2);
+        assert_eq!(
+            selector.0.get(0).unwrap(),
+            &Selector {
+                negate: true,
+                key: "env".to_string(),
+                requirement: Some(Restriction {
+                    operator: Operator::In,
+                    values: vec!["prod".to_string(), "test".to_string()],
+                }),
+            }
+        );
+        assert_eq!(
+            selector.0.get(1).unwrap(),
+            &Selector {
+                negate: false,
+                key: "app".to_string(),
+                requirement: Some(Restriction {
+                    operator: Operator::NotIn,
+                    values: vec!["sentry".to_string()],
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn from_str_with_trailing_data_fails() {
+        assert!(Selectors::try_from("env=prod trailing").is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `ConfigResource::event_matches`
- extend selector parser tests for negation and invalid strings

## Testing
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_684fd4be15fc83339ca62ef089956021